### PR TITLE
Add picker refresh to delete_mark

### DIFF
--- a/lua/telescope/_extensions/harpoonEx.lua
+++ b/lua/telescope/_extensions/harpoonEx.lua
@@ -107,6 +107,7 @@ local actions = {
 		current_picker:delete_selection(function(selection)
 			harpoonEx.delete(harpoon:list(), selection.value[1])
 		end)
+		current_picker:refresh(make_finder(harpoon:list()), { reset_prompt = true })
 	end,
 
 	move_mark_up = function(prompt_bufnr)


### PR DESCRIPTION
Hi. I added `current_picker:refresh()` to `delete_mark()`.

I think the picker should be refreshed after every single deletion. Isn't it?