### PR TITLE
Fix global M

### DIFF
--- a/lua/harpoonEx/init.lua
+++ b/lua/harpoonEx/init.lua
@@ -1,4 +1,4 @@
-M = {}
+local M = {}
 
 M.index = {}
 


### PR DESCRIPTION
This fixes some issues I was having with `M.index` is `nil` errors caused by other plugins also not using a `local` `M` and overwriting this plugin's attributes.